### PR TITLE
Bugfix: sizeof is used on a pointer when it should refer to its data

### DIFF
--- a/inc/tun-open.h
+++ b/inc/tun-open.h
@@ -19,7 +19,7 @@ typedef struct TunOpenNameS {
  * @param[out] tunName the actual name of the tun device (may be NULL)
  * @return return the new file descriptor or -1 if an error occurred (in which case, errno is set appropriately)
  */
-int tunOpen(const char* name, TunOpenName* tunName);
+int tunOpen(const char *name, TunOpenName *tunName);
 
 /// The offset of the packet in the buffer of a read/write call
 #define TUN_OPEN_PACKET_OFFSET 4

--- a/src/tun-open.c
+++ b/src/tun-open.c
@@ -40,7 +40,7 @@
 #define CHK(var, call) do { var = call; (void) var; } while (0)
 #endif
 
-int tunOpen(const char* name, TunOpenName* tunName) {
+int tunOpen(const char *name, TunOpenName *tunName) {
 #if __APPLE__
 	u_int32_t numdev = 0;  // create new
 	if (name) {
@@ -77,8 +77,8 @@ int tunOpen(const char* name, TunOpenName* tunName) {
 	CHK(err, connect(fd, (const struct sockaddr *) &addr, sizeof(addr)));
 
 	if (tunName) {
-		socklen_t optlen = sizeof(tunName);
-		CHK(err, getsockopt(fd, SYSPROTO_CONTROL, UTUN_OPT_IFNAME, tunName, &optlen));
+		socklen_t optlen = sizeof(tunName->name);
+		CHK(err, getsockopt(fd, SYSPROTO_CONTROL, UTUN_OPT_IFNAME, tunName->name, &optlen));
 	}
 
 	return fd;


### PR DESCRIPTION
This pull request fixes issue #1.

This pull request changes tun_open.c to use tunName->name as the buffer in code, making the compiler recognize its proper size when calculating `sizeof`. Additionally, some other small adjustments have been made to make the use of pointers more explicit.